### PR TITLE
#238 fix: 로딩페이지 css 수정

### DIFF
--- a/src/pages/LoadingPage.jsx
+++ b/src/pages/LoadingPage.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { ReactComponent as LoadingLogo } from '/public/assets/loadingLogo.svg'
 const LoadingPage = () => {
   return (
-    <div className="w-screen h-screen relative  flex justify-center items-center bg-primary z-[100]">
+    <div className="w-screen h-screen fixed top-0 left-0 flex justify-center items-center bg-primary z-[100]">
       <LoadingLogo className="w-36" />
     </div>
   )


### PR DESCRIPTION
#238 

로딩페이지에서 position 속성을 absolute로 주고 top과 left를 0으로 지정하여 로딩페이지가 항상 전체 화면을 덮을 수 있도록 수정하였습니다. 